### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  # before_action :set_item, except: [:index, :new, :create]
+  before_action :set_item, except: [:index, :new, :create]
   # before_action :contributor_confirmation, only: [:edit, :update, :destroy]
 
   def index
@@ -30,9 +30,9 @@ class ItemsController < ApplicationController
                                  :shipping_date_id, :image).merge(user_id: current_user.id)
   end
 
-  # def set_item
-  #   @item = Item.find(params[:id])
-  # end
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   # def contributor_confirmation
   #   redirect_to root_path unless current_user == @item.user

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,17 @@
     </div>
 
     <% if user_signed_in?%> 
-      <%if current_user.id == @item.user_id %>
+      <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集",  edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
-      <% end %>
+      <% else %>
 
       <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%if current_user.id != @item.user_id %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-      <% end %>
       <%# //商品が売れていない場合はこちらを表示しましょう %>
-      
+      <% end %>
+
     <% end %>
 
     <div class="item-explain-box">
@@ -104,7 +103,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
+      <%#<div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+
     </div>
     <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
+      <span class="item-price"><%= @item.price %>円</span>
+      <span class="item-postage"><%= @item.shipping_charge.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <%#<% if user_signed_in? && current_user.id == item.user_id %>
+    <% if user_signed_in?%> 
+      <%if current_user.id == @item.user_id %>
+        <%= link_to "商品の編集",  edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
+      <% end %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <%#<% end %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%if current_user.id != @item.user_id %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# what
下記実装条件を満たしたプロダクトの作成
- 商品詳細表示ページは、ログイン状況や商品の販売状況に関係なく、誰でも見ることができること。
- 商品一覧ページにて商品情報をクリックすると、該当する商品の商品詳細表示ページへ遷移すること。
- 商品出品時に登録した情報（商品名・商品画像・価格・配送料の負担・商品の説明・出品者名・カテゴリー・商品の状態・発送元の地域・発送日の目安）が、見本アプリと同様の形で表示されること。
- 画像が表示されており、画像がリンク切れなどにならないこと（デプロイのタスクにあるとおり、実装中にHerokuの仕様による商品画像が適切に表示されなくなる問題は発生するが、最後にS3を導入することで、この問題は解消される）。
- ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。
- ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。
- ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。

# why
商品詳細ページの閲覧を可能にするため
適切な情報が表示されるように記述した

# gyazo
- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/0f3ea2c7c2ba0730b6966d58e4cde7b6

- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/749d3cea186ddb0109765291a9acd2b0

- ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/59677084c4d57ac5d2ab12792e20c0eb